### PR TITLE
KL Divergence: use epsilon smoothing for zero-frequency events

### DIFF
--- a/src/com/jgaap/distances/KullbackLeiblerDivergence.java
+++ b/src/com/jgaap/distances/KullbackLeiblerDivergence.java
@@ -19,6 +19,9 @@
  **/
 package com.jgaap.distances;
 
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 import com.jgaap.generics.DivergenceFunction;
 import com.jgaap.util.Event;
 import com.jgaap.util.Histogram;
@@ -58,10 +61,15 @@ public class KullbackLeiblerDivergence extends DivergenceFunction {
     @Override
     public double divergence(Histogram unknownHistogram, Histogram knownHistogram) {
         double distance = 0;
+        double epsilon = 1e-10;
 
-        for(Event event : unknownHistogram.uniqueEvents()) {
-            if(knownHistogram.contains(event)){
-             distance += unknownHistogram.relativeFrequency(event) * Math.log(unknownHistogram.relativeFrequency(event)/knownHistogram.relativeFrequency(event)); 
+        Set<Event> events = Sets.union(unknownHistogram.uniqueEvents(), knownHistogram.uniqueEvents());
+        for (Event event : events) {
+            double p = unknownHistogram.relativeFrequency(event);
+            if (p > 0) {
+                double q = knownHistogram.relativeFrequency(event);
+                double smoothedQ = (q > 0) ? q : epsilon;
+                distance += p * Math.log(p / smoothedQ);
             }
         }
         return Math.abs(distance);


### PR DESCRIPTION
Fixes #139

The divergence function was only iterating over events in the unknown histogram and skipping any event where the known histogram had a frequency of zero. So if a word appears in the unknown document but not the known one, that term gets dropped entirely. That understates the divergence and throws away a real signal.

Switched to iterating over the union of both histograms and substituting epsilon (1e-10) for any zero known-frequency term instead of skipping it. For events where both frequencies are already positive nothing changes, so existing test values are unaffected.