### PR TITLE
Angular Separation and Chord Distance: fix cosine similarity calculation

### DIFF
--- a/src/com/jgaap/distances/AngularSeparationDistance.java
+++ b/src/com/jgaap/distances/AngularSeparationDistance.java
@@ -10,10 +10,10 @@ import com.jgaap.util.Histogram;
 
 /**
  * Angular Separation Distance
- * d = 1 - ( sum( xi * yi ) / sqrt( sum(xi)^2 * sum( yi )^2 ) )
- * 
+ * d = arccos( sum(xi*yi) / sqrt(sum(xi^2) * sum(yi^2)) ) / pi
+ *
  * @author Adam Sargent
- * @version 1.0
+ * @version 1.1
  */
 
 public class AngularSeparationDistance extends DistanceFunction {
@@ -43,10 +43,11 @@ public class AngularSeparationDistance extends DistanceFunction {
 		
 		for(Event event : events){
 			sumNumer += unknownHistogram.relativeFrequency(event) * knownHistogram.relativeFrequency(event);
-			sumUnknown += unknownHistogram.relativeFrequency(event);
-			sumKnown += knownHistogram.relativeFrequency(event);
+			sumUnknown += Math.pow(unknownHistogram.relativeFrequency(event), 2);
+			sumKnown += Math.pow(knownHistogram.relativeFrequency(event), 2);
 		}
-		distance = 1 - (sumNumer / Math.sqrt(sumUnknown * sumUnknown * sumKnown * sumKnown));
+		double cosine = sumNumer / Math.sqrt(sumUnknown * sumKnown);
+		distance = Math.acos(Math.min(1.0, cosine)) / Math.PI;
 		return distance;
 	}
 

--- a/src/com/jgaap/distances/ChordDistance.java
+++ b/src/com/jgaap/distances/ChordDistance.java
@@ -10,10 +10,10 @@ import com.jgaap.util.Histogram;
 
 /**
  * Chord Distance
- * d = sqrt( 2 - 2 * (sum(xi * yi)/sqrt( sum(xi)^2 * sum(yi)^2 )) )
- * 
+ * d = sqrt( 2 - 2 * (sum(xi*yi) / sqrt(sum(xi^2) * sum(yi^2))) )
+ *
  * @author Adam Sargent
- * @version 1.0
+ * @version 1.1
  */
 
 public class ChordDistance extends DistanceFunction {
@@ -42,10 +42,11 @@ public class ChordDistance extends DistanceFunction {
 		
 		for(Event event : events){
 			sumNumer += unknownHistogram.relativeFrequency(event) * knownHistogram.relativeFrequency(event);
-			sumUnknown += unknownHistogram.relativeFrequency(event);
-			sumKnown += knownHistogram.relativeFrequency(event);
+			sumUnknown += Math.pow(unknownHistogram.relativeFrequency(event), 2);
+			sumKnown += Math.pow(knownHistogram.relativeFrequency(event), 2);
 		}
-		distance = Math.sqrt(2 - 2 * (sumNumer / Math.sqrt(sumUnknown * sumUnknown * sumKnown * sumKnown)));
+		double cosine = sumNumer / Math.sqrt(sumUnknown * sumKnown);
+		distance = Math.sqrt(2 - 2 * Math.min(1.0, cosine));
 		
 		return distance;
 	}

--- a/unittests/com/jgaap/distances/AngularSeparationDistanceTest.java
+++ b/unittests/com/jgaap/distances/AngularSeparationDistanceTest.java
@@ -32,9 +32,9 @@ public class AngularSeparationDistanceTest {
 		set1.addEvents(test1);
 		set2.addEvents(test1);
 		double result = new AngularSeparationDistance().distance(new EventMap(set1), new EventMap(set2));
-		assertTrue(DistanceTestHelper.inRange(result, 0.90, 0.0000000001));
-		
-		
+		assertTrue(DistanceTestHelper.inRange(result, 0.0, 0.0000000001));
+
+
 		set2 = new EventSet();
 		Vector<Event> test2 = new Vector<Event>();
 		test2.add(new Event("1", null));
@@ -49,7 +49,7 @@ public class AngularSeparationDistanceTest {
 		test2.add(new Event("10", null));
 		set2.addEvents(test2);
 		result = new AngularSeparationDistance().distance(new EventMap(set1), new EventMap(set2));
-		assertTrue(DistanceTestHelper.inRange(result, 1.0, 0.0000000001));
+		assertTrue(DistanceTestHelper.inRange(result, 0.5, 0.0000000001));
 	}
 
 }

--- a/unittests/com/jgaap/distances/ChordDistanceTest.java
+++ b/unittests/com/jgaap/distances/ChordDistanceTest.java
@@ -32,7 +32,7 @@ public class ChordDistanceTest {
 		set1.addEvents(test1);
 		set2.addEvents(test1);
 		double result = new ChordDistance().distance(new EventMap(set1), new EventMap(set2));
-		assertTrue(DistanceTestHelper.inRange(result, Math.sqrt(1.8), 0.0000000001));
+		assertTrue(DistanceTestHelper.inRange(result, 0.0, 0.0000000001));
 		
 		
 		set2 = new EventSet();


### PR DESCRIPTION
Fixes #140

Both functions had the wrong denominator for cosine similarity. They were summing raw frequencies instead of squared frequencies, which for a normalized histogram means the denominator collapses to sum(xi) * sum(yi) = 1 * 1 = 1. Effectively both were computing the dot product with no normalization at all.

Fixed by accumulating sum(xi^2) and sum(yi^2) in the loop and using sqrt(sumXX * sumYY) as the denominator, which is the standard L2 norm approach.

Angular Separation also now returns arccos(cosine) / pi instead of 1 - cosine. The old formula is a cosine distance approximation, not an actual angular measure. The arccos version gives a properly normalized angle in the range [0, 1].

Chord Distance's sqrt(2 - 2 * cosine) formula was already mathematically correct and just needed an accurate cosine value to work. Test expected values updated to match corrected output — identical vectors now return 0.0 for both functions instead of 0.9 and sqrt(1.8).